### PR TITLE
Feature/weiche change work status in detail issue page

### DIFF
--- a/components/IssueDetailCard.tsx
+++ b/components/IssueDetailCard.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react'
 
-import Router from 'next/router';
-import { useSession } from 'next-auth/react';
+import { useSession } from 'next-auth/react'
 
-import Button from './Button';
+import { closeIssue } from './fetchGitHubApi'
+import Button from './Button'
 import MoreOptionDropDown from './MoreOptionDropDown'
-import { WorkStatus } from '@/modules/WorkStatus';
+import { WorkStatus } from '@/modules/WorkStatus'
 
 type IssueDetailCardProps = {
     username: string;
@@ -27,21 +27,8 @@ const IssueDetailCard = (props: IssueDetailCardProps) => {
         setToken(session?.accessToken)
     }, [])
 
-
-    const closeIssue = async () => {
-        fetch(`https://api.github.com/repos/${props.username}/${props.reponame}/issues/${props.issue}`, {
-            method: 'PATCH',
-            body: JSON.stringify({
-                state: 'closed',
-            }),
-            headers: {
-                'Authorization': `bearer ${token}`,
-                'Content-type': 'application/json; charset=UTF-8',
-            },
-        })
-            .then((response) => response.json())
-            .then((json) => console.log(json));
-        Router.push(`/${props.username}/${props.reponame}/issues`)
+    const handleDeleteButtonClick = () => {
+        closeIssue(props.username, props.reponame, props.issue, token)
     }
 
     return (
@@ -58,7 +45,7 @@ const IssueDetailCard = (props: IssueDetailCardProps) => {
                         {props.state === 'open' && props.workStatus === WorkStatus.NoLabel && <Button className='ease-in duration-300 bg-gray-300 text-black hover:bg-gray-500 hover:text-white px-6' onClick={() => { }}>{props.workStatus}</Button>}
                     </div>
                 </div>
-                <MoreOptionDropDown onDeleteButtonClick={closeIssue} />
+                <MoreOptionDropDown onDeleteButtonClick={handleDeleteButtonClick} />
             </div>
             <div className='m-10'>
                 <h4 className='mt-10 font-bold'>{`${props.title}`}</h4>

--- a/components/IssueDetailCard.tsx
+++ b/components/IssueDetailCard.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 
 import { useSession } from 'next-auth/react'
 
-import { closeIssue } from './fetchGitHubApi'
+import { updateIssue } from './fetchGitHubApi'
 import Button from './Button'
 import MoreOptionDropDown from './MoreOptionDropDown'
 import WorkStatusDropDown from './WorkStatusDropDown'
@@ -28,15 +28,33 @@ const IssueDetailCard = (props: IssueDetailCardProps) => {
         setToken(session?.accessToken)
     }, [])
 
+    const handleOpenStatusButtonClick = () => {
+        const ReqBody = { labels: [WorkStatus.Open] }
+        updateIssue(props.username, props.reponame, props.issue, token, ReqBody)
+    }
+
+    const handleInProgressStatusButtonClick = () => {
+        const ReqBody = { labels: [WorkStatus.InProgress] }
+        updateIssue(props.username, props.reponame, props.issue, token, ReqBody)
+    }
+
+    const handleDoneStatusButtonClick = () => {
+        const ReqBody = { labels: [WorkStatus.Done] }
+        updateIssue(props.username, props.reponame, props.issue, token, ReqBody)
+    }
+
     const handleDeleteButtonClick = () => {
-        closeIssue(props.username, props.reponame, props.issue, token)
+        const ReqBody = { state: 'closed' }
+        updateIssue(props.username, props.reponame, props.issue, token, ReqBody)
     }
 
     return (
         <div className='m-2 bg-gray-200  dark:bg-gray-700 border dark:border-gray-700 rounded-lg'>
             <div className='m-10 flex items-center justify-between'>
                 <div className='flex items-center justify-start'>
-                    {props.state === 'open' && <WorkStatusDropDown workStatus={props.workStatus} />}
+                    {props.state === 'open' &&
+                        <WorkStatusDropDown workStatus={props.workStatus}
+                            onOpenStatusButtonClick={handleOpenStatusButtonClick} onInProgressStatusButtonClick={handleInProgressStatusButtonClick} onDoneStatusButtonClick={handleDoneStatusButtonClick} />}
                     <div>
                         {props.state === 'closed' && <Button className='mr-2 ease-in duration-300 bg-gray-300 text-black hover:bg-gray-500 hover:text-white px-6' onClick={() => { }}>Closed</Button>}
                     </div>
@@ -44,7 +62,7 @@ const IssueDetailCard = (props: IssueDetailCardProps) => {
                 <MoreOptionDropDown onDeleteButtonClick={handleDeleteButtonClick} />
             </div>
             <div className='m-10'>
-                <h4 className='mt-10 font-bold'>{`${props.title}`}</h4>
+                <h4 className='mt-10 font-bold'>{`#${props.issue} ${props.title}`}</h4>
                 <p className='mt-5'>{props.body}</p>
             </div>
             <div></div>

--- a/components/IssueDetailCard.tsx
+++ b/components/IssueDetailCard.tsx
@@ -28,23 +28,7 @@ const IssueDetailCard = (props: IssueDetailCardProps) => {
         setToken(session?.accessToken)
     }, [])
 
-    const handleOpenStatusButtonClick = () => {
-        const ReqBody = { labels: [WorkStatus.Open] }
-        updateIssue(props.username, props.reponame, props.issue, token, ReqBody)
-    }
-
-    const handleInProgressStatusButtonClick = () => {
-        const ReqBody = { labels: [WorkStatus.InProgress] }
-        updateIssue(props.username, props.reponame, props.issue, token, ReqBody)
-    }
-
-    const handleDoneStatusButtonClick = () => {
-        const ReqBody = { labels: [WorkStatus.Done] }
-        updateIssue(props.username, props.reponame, props.issue, token, ReqBody)
-    }
-
-    const handleDeleteButtonClick = () => {
-        const ReqBody = { state: 'closed' }
+    const handleStatusButtonClick = (ReqBody: any) => {
         updateIssue(props.username, props.reponame, props.issue, token, ReqBody)
     }
 
@@ -54,12 +38,14 @@ const IssueDetailCard = (props: IssueDetailCardProps) => {
                 <div className='flex items-center justify-start'>
                     {props.state === 'open' &&
                         <WorkStatusDropDown workStatus={props.workStatus}
-                            onOpenStatusButtonClick={handleOpenStatusButtonClick} onInProgressStatusButtonClick={handleInProgressStatusButtonClick} onDoneStatusButtonClick={handleDoneStatusButtonClick} />}
+                            onOpenStatusButtonClick={() => { handleStatusButtonClick({ labels: [WorkStatus.Open] }) }}
+                            onInProgressStatusButtonClick={() => { handleStatusButtonClick({ labels: [WorkStatus.InProgress] }) }}
+                            onDoneStatusButtonClick={() => { handleStatusButtonClick({ labels: [WorkStatus.Done] }) }} />}
                     <div>
                         {props.state === 'closed' && <Button className='mr-2 ease-in duration-300 bg-gray-300 text-black hover:bg-gray-500 hover:text-white px-6' onClick={() => { }}>Closed</Button>}
                     </div>
                 </div>
-                <MoreOptionDropDown onDeleteButtonClick={handleDeleteButtonClick} />
+                <MoreOptionDropDown onDeleteButtonClick={() => { handleStatusButtonClick({ state: 'closed' }) }} />
             </div>
             <div className='m-10'>
                 <h4 className='mt-10 font-bold'>{`#${props.issue} ${props.title}`}</h4>

--- a/components/IssueDetailCard.tsx
+++ b/components/IssueDetailCard.tsx
@@ -5,6 +5,7 @@ import { useSession } from 'next-auth/react'
 import { closeIssue } from './fetchGitHubApi'
 import Button from './Button'
 import MoreOptionDropDown from './MoreOptionDropDown'
+import WorkStatusDropDown from './WorkStatusDropDown'
 import { WorkStatus } from '@/modules/WorkStatus'
 
 type IssueDetailCardProps = {
@@ -35,14 +36,9 @@ const IssueDetailCard = (props: IssueDetailCardProps) => {
         <div className='m-2 bg-gray-200  dark:bg-gray-700 border dark:border-gray-700 rounded-lg'>
             <div className='m-10 flex items-center justify-between'>
                 <div className='flex items-center justify-start'>
+                    {props.state === 'open' && <WorkStatusDropDown workStatus={props.workStatus} />}
                     <div>
                         {props.state === 'closed' && <Button className='mr-2 ease-in duration-300 bg-gray-300 text-black hover:bg-gray-500 hover:text-white px-6' onClick={() => { }}>Closed</Button>}
-                    </div>
-                    <div>
-                        {props.state === 'open' && props.workStatus === WorkStatus.Open && <Button className='ease-in duration-300 bg-blue-300 text-black hover:bg-blue-500 hover:text-white px-6' onClick={() => { }}>{props.workStatus}</Button>}
-                        {props.state === 'open' && props.workStatus === WorkStatus.InProgress && <Button className='ease-in duration-300 bg-red-300 text-black hover:bg-red-500 hover:text-white px-6' onClick={() => { }}>{props.workStatus}</Button>}
-                        {props.state === 'open' && props.workStatus === WorkStatus.Done && <Button className='ease-in duration-300 bg-green-300 text-black hover:bg-green-500 hover:text-white px-6' onClick={() => { }}>{props.workStatus}</Button>}
-                        {props.state === 'open' && props.workStatus === WorkStatus.NoLabel && <Button className='ease-in duration-300 bg-gray-300 text-black hover:bg-gray-500 hover:text-white px-6' onClick={() => { }}>{props.workStatus}</Button>}
                     </div>
                 </div>
                 <MoreOptionDropDown onDeleteButtonClick={handleDeleteButtonClick} />

--- a/components/MoreOptionDropDown.tsx
+++ b/components/MoreOptionDropDown.tsx
@@ -1,5 +1,6 @@
 import { Fragment, MouseEventHandler } from 'react'
 import { Menu, Transition } from '@headlessui/react'
+
 import { EllipsisVerticalIcon, PencilSquareIcon, TrashIcon } from '@heroicons/react/20/solid'
 
 type MoreOptionDropDownProps = {

--- a/components/MoreOptionDropDown.tsx
+++ b/components/MoreOptionDropDown.tsx
@@ -2,11 +2,11 @@ import { Fragment, MouseEventHandler } from 'react'
 import { Menu, Transition } from '@headlessui/react'
 import { EllipsisVerticalIcon, PencilSquareIcon, TrashIcon } from '@heroicons/react/20/solid'
 
-const classNames = (...classes: string[]) => { return classes.filter(Boolean).join(' ') }
-
 type MoreOptionDropDownProps = {
     onDeleteButtonClick: MouseEventHandler<HTMLButtonElement>;
 }
+
+const classNames = (...classes: string[]) => { return classes.filter(Boolean).join(' ') }
 
 const MoreOptionDropDown = (props: MoreOptionDropDownProps) => {
     return (

--- a/components/WorkStatusDropDown.tsx
+++ b/components/WorkStatusDropDown.tsx
@@ -1,22 +1,19 @@
-import { Fragment } from 'react'
+import { Fragment, MouseEventHandler } from 'react'
 import { Menu, Transition } from '@headlessui/react'
+
 import { ChevronDownIcon, DocumentIcon, DocumentTextIcon, DocumentCheckIcon } from '@heroicons/react/20/solid'
 import { WorkStatus } from '@/modules/WorkStatus'
 
 type WorkStatusDropDownProps = {
-    // state: string;
-    // title: string;
-    // body: string;
     workStatus: string;
-    // className: string;
-    // onClick: MouseEventHandler;
+    onOpenStatusButtonClick: MouseEventHandler<HTMLButtonElement>;
+    onInProgressStatusButtonClick: MouseEventHandler<HTMLButtonElement>;
+    onDoneStatusButtonClick: MouseEventHandler<HTMLButtonElement>;
 }
 
 const classNames = (...classes: string[]) => {
     return classes.filter(Boolean).join(' ')
 }
-
-
 
 const WorkStatusDropDown = (props: WorkStatusDropDownProps) => {
     let menuButtonClass = ''
@@ -62,41 +59,26 @@ const WorkStatusDropDown = (props: WorkStatusDropDownProps) => {
                     <div className="py-1">
                         <Menu.Item>
                             {({ active }) => (
-                                <a
-                                    href="#"
-                                    className={classNames(
-                                        active ? 'bg-gray-300 text-blue-500' : 'bg-gray-100 text-blue-500',
-                                        'flex flex-row justify-start items-center px-4 py-2 text-sm ease-in duration-300'
-                                    )}
-                                >
+                                <button onClick={props.onOpenStatusButtonClick} className={classNames(active ? 'bg-gray-300 text-blue-500' : 'bg-gray-100 text-blue-500',
+                                    'flex flex-row justify-start items-center w-full px-4 py-2 text-left text-sm ease-in duration-300')}>
                                     <DocumentIcon className="h-4 w-4 mr-2" aria-hidden="true" /> {WorkStatus.Open}
-                                </a>
+                                </button>
                             )}
                         </Menu.Item>
                         <Menu.Item>
                             {({ active }) => (
-                                <a
-                                    href="#"
-                                    className={classNames(
-                                        active ? 'bg-gray-300 text-red-500' : 'bg-gray-100 text-red-500',
-                                        'flex flex-row justify-start items-center px-4 py-2 text-sm ease-in duration-300'
-                                    )}
-                                >
+                                <button onClick={props.onInProgressStatusButtonClick} className={classNames(active ? 'bg-gray-300 text-red-500' : 'bg-gray-100 text-red-500',
+                                    'flex flex-row justify-start items-center w-full px-4 py-2 text-left text-sm ease-in duration-300')}>
                                     <DocumentTextIcon className="h-4 w-4 mr-2" aria-hidden="true" /> {WorkStatus.InProgress}
-                                </a>
+                                </button>
                             )}
                         </Menu.Item>
                         <Menu.Item>
                             {({ active }) => (
-                                <a
-                                    href="#"
-                                    className={classNames(
-                                        active ? 'bg-gray-300 text-green-500' : 'bg-gray-100 text-green-500',
-                                        'flex flex-row justify-start items-center px-4 py-2 text-sm ease-in duration-300'
-                                    )}
-                                >
+                                <button onClick={props.onDoneStatusButtonClick} className={classNames(active ? 'bg-gray-300 text-green-500' : 'bg-gray-100 text-green-500',
+                                    'flex flex-row justify-start items-center w-full px-4 py-2 text-left text-sm ease-in duration-300')}>
                                     <DocumentCheckIcon className="h-4 w-4 mr-2" aria-hidden="true" /> {WorkStatus.Done}
-                                </a>
+                                </button>
                             )}
                         </Menu.Item>
                     </div>

--- a/components/WorkStatusDropDown.tsx
+++ b/components/WorkStatusDropDown.tsx
@@ -1,0 +1,109 @@
+import { Fragment } from 'react'
+import { Menu, Transition } from '@headlessui/react'
+import { ChevronDownIcon, DocumentIcon, DocumentTextIcon, DocumentCheckIcon } from '@heroicons/react/20/solid'
+import { WorkStatus } from '@/modules/WorkStatus'
+
+type WorkStatusDropDownProps = {
+    // state: string;
+    // title: string;
+    // body: string;
+    workStatus: string;
+    // className: string;
+    // onClick: MouseEventHandler;
+}
+
+const classNames = (...classes: string[]) => {
+    return classes.filter(Boolean).join(' ')
+}
+
+
+
+const WorkStatusDropDown = (props: WorkStatusDropDownProps) => {
+    let menuButtonClass = ''
+
+    switch (props.workStatus) {
+        case WorkStatus.Open: {
+            menuButtonClass = 'inline-flex w-full justify-center rounded-md hover:ring-2 hover:ring-gray-300  bg-blue-300 px-4 py-2 text-sm font-medium text-black shadow-sm hover:bg-blue-500 hover:text-white focus:outline-none focus:ring-2 ease-in duration-300'
+            break;
+        }
+        case WorkStatus.InProgress: {
+            menuButtonClass = 'inline-flex w-full justify-center rounded-md hover:ring-2 hover:ring-gray-300  bg-red-300 px-4 py-2 text-sm font-medium text-black shadow-sm hover:bg-red-500 hover:text-white focus:outline-none focus:ring-2 ease-in duration-300'
+            break;
+        }
+        case WorkStatus.Done: {
+            menuButtonClass = 'inline-flex w-full justify-center rounded-md hover:ring-2 hover:ring-gray-300  bg-green-300 px-4 py-2 text-sm font-medium text-black shadow-sm hover:bg-green-500 hover:text-white focus:outline-none focus:ring-2 ease-in duration-300'
+            break;
+        }
+        default: {
+            menuButtonClass = 'inline-flex w-full justify-center rounded-md hover:ring-2 hover:ring-gray-300  bg-gray-300 px-4 py-2 text-sm font-medium text-black shadow-sm hover:bg-gray-500 hover:text-white focus:outline-none focus:ring-2 ease-in duration-300'
+            break;
+        }
+    }
+
+    return (
+        <Menu as="div" className="relative inline-block text-left">
+            <div>
+                <Menu.Button className={menuButtonClass}>
+                    {props.workStatus}
+                    <ChevronDownIcon className="-mr-1 ml-2 h-5 w-5" aria-hidden="true" />
+                </Menu.Button>
+            </div>
+
+            <Transition
+                as={Fragment}
+                enter="transition ease-out duration-100"
+                enterFrom="transform opacity-0 scale-95"
+                enterTo="transform opacity-100 scale-100"
+                leave="transition ease-in duration-75"
+                leaveFrom="transform opacity-100 scale-100"
+                leaveTo="transform opacity-0 scale-95"
+            >
+                <Menu.Items className="absolute right-0 z-10 mt-2 w-56 origin-top-right rounded-md bg-gray-100 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
+                    <div className="py-1">
+                        <Menu.Item>
+                            {({ active }) => (
+                                <a
+                                    href="#"
+                                    className={classNames(
+                                        active ? 'bg-gray-300 text-blue-500' : 'bg-gray-100 text-blue-500',
+                                        'flex flex-row justify-start items-center px-4 py-2 text-sm ease-in duration-300'
+                                    )}
+                                >
+                                    <DocumentIcon className="h-4 w-4 mr-2" aria-hidden="true" /> {WorkStatus.Open}
+                                </a>
+                            )}
+                        </Menu.Item>
+                        <Menu.Item>
+                            {({ active }) => (
+                                <a
+                                    href="#"
+                                    className={classNames(
+                                        active ? 'bg-gray-300 text-red-500' : 'bg-gray-100 text-red-500',
+                                        'flex flex-row justify-start items-center px-4 py-2 text-sm ease-in duration-300'
+                                    )}
+                                >
+                                    <DocumentTextIcon className="h-4 w-4 mr-2" aria-hidden="true" /> {WorkStatus.InProgress}
+                                </a>
+                            )}
+                        </Menu.Item>
+                        <Menu.Item>
+                            {({ active }) => (
+                                <a
+                                    href="#"
+                                    className={classNames(
+                                        active ? 'bg-gray-300 text-green-500' : 'bg-gray-100 text-green-500',
+                                        'flex flex-row justify-start items-center px-4 py-2 text-sm ease-in duration-300'
+                                    )}
+                                >
+                                    <DocumentCheckIcon className="h-4 w-4 mr-2" aria-hidden="true" /> {WorkStatus.Done}
+                                </a>
+                            )}
+                        </Menu.Item>
+                    </div>
+                </Menu.Items>
+            </Transition>
+        </Menu>
+    )
+}
+
+export default WorkStatusDropDown

--- a/components/fetchGitHubApi.tsx
+++ b/components/fetchGitHubApi.tsx
@@ -1,0 +1,70 @@
+import Router from 'next/router'
+import { WorkStatus } from '@/modules/WorkStatus'
+
+// Function to fetch the specific repository issue, ref in file [issue].tsx
+export const fetchRepoIssue = async (username: string, reponame: string, issue: number, setData: any, setStatus: any, setLoading: any) => {
+    setLoading(true)
+    fetch(`https://api.github.com/repos/${username}/${reponame}/issues/${issue}`)
+        .then(response => response.json())
+        .then(data => {
+            // Updating the repository issues state with the received data
+            setData(data)
+            for (let label of data.labels) {
+                for (let key in label) {
+                    if (key === 'name' && label[key] in WorkStatus) {
+                        setStatus(label[key])
+                    }
+                }
+            }
+            setLoading(false)
+        })
+        .catch(error => console.error(error))
+}
+
+// Asynchronously fetch the repositories for the given username, ref in file repoList.tsx
+export const fetchRepos = async (username: string, setData: any, setLoading: any) => {
+    setLoading(true)
+    fetch(`https://api.github.com/users/${username}/repos`)
+        .then(response => response.json())
+        .then(data => {
+            setData(data)
+            setLoading(false)
+        })
+        .catch(error => console.error(error))
+}
+
+// Function to fetch the repository issues from Github API, ref in file issueList.tsx
+export const fetchRepoIssues = async (username: string, reponame: string, page: number, setData: any, setLoadMore: any, setLoading: any) => {
+    setLoading(true)
+    fetch(`https://api.github.com/repos/${username}/${reponame}/issues?per_page=${page}`)
+        .then(response => response.json())
+        .then(data => {
+            // If number of issues received is less than the requested page, it means there are no more issues to be loaded
+            if (data.length < page) {
+                setLoadMore(false)
+            }
+            // Updating the repository issues state with the received data
+            setData(data)
+            setLoading(false)
+            console.log(`Load page ${page / 10}`, data)
+        })
+        .catch(error => console.error(error))
+}
+
+// Function to update issue's state to 'closed', the operation equals to delete task, ref in file IssueDetailCard.tsx
+export const closeIssue = async (username: string, reponame: string, issue: number, token: string,) => {
+    fetch(`https://api.github.com/repos/${username}/${reponame}/issues/${issue}`, {
+        method: 'PATCH',
+        body: JSON.stringify({
+            state: 'closed',
+        }),
+        headers: {
+            'Authorization': `bearer ${token}`,
+            'Content-type': 'application/json; charset=UTF-8',
+        },
+    })
+        .then((response) => response.json())
+        .then((json) => console.log(json));
+    Router.push(`/${username}/${reponame}/issues`)
+}
+

--- a/components/fetchGitHubApi.tsx
+++ b/components/fetchGitHubApi.tsx
@@ -52,7 +52,7 @@ export const fetchRepoIssues = async (username: string, reponame: string, page: 
 }
 
 // Function to update issue's state depend on reqBody, it could be update either state, label, title, or body, ref in file IssueDetailCard.tsx
-export const updateIssue = async (username: string, reponame: string, issue: number, token: string, reqBody: object) => {
+export const updateIssue = async (username: string, reponame: string, issue: number, token: string, reqBody: any) => {
     fetch(`https://api.github.com/repos/${username}/${reponame}/issues/${issue}`, {
         method: 'PATCH',
         body: JSON.stringify(reqBody),
@@ -64,7 +64,6 @@ export const updateIssue = async (username: string, reponame: string, issue: num
         .then((response) => response.json())
         .then((json) => console.log(json));
 
-    //@ts-ignore
     if (reqBody.state) {
         Router.push(`/${username}/${reponame}/issues`)
     } else {

--- a/components/fetchGitHubApi.tsx
+++ b/components/fetchGitHubApi.tsx
@@ -51,13 +51,11 @@ export const fetchRepoIssues = async (username: string, reponame: string, page: 
         .catch(error => console.error(error))
 }
 
-// Function to update issue's state to 'closed', the operation equals to delete task, ref in file IssueDetailCard.tsx
-export const closeIssue = async (username: string, reponame: string, issue: number, token: string,) => {
+// Function to update issue's state depend on reqBody, it could be update either state, label, title, or body, ref in file IssueDetailCard.tsx
+export const updateIssue = async (username: string, reponame: string, issue: number, token: string, reqBody: object) => {
     fetch(`https://api.github.com/repos/${username}/${reponame}/issues/${issue}`, {
         method: 'PATCH',
-        body: JSON.stringify({
-            state: 'closed',
-        }),
+        body: JSON.stringify(reqBody),
         headers: {
             'Authorization': `bearer ${token}`,
             'Content-type': 'application/json; charset=UTF-8',
@@ -65,6 +63,12 @@ export const closeIssue = async (username: string, reponame: string, issue: numb
     })
         .then((response) => response.json())
         .then((json) => console.log(json));
-    Router.push(`/${username}/${reponame}/issues`)
+
+    //@ts-ignore
+    if (reqBody.state) {
+        Router.push(`/${username}/${reponame}/issues`)
+    } else {
+        Router.reload()
+    }
 }
 

--- a/components/fetchGitHubApi.tsx
+++ b/components/fetchGitHubApi.tsx
@@ -66,8 +66,6 @@ export const updateIssue = async (username: string, reponame: string, issue: num
 
     if (reqBody.state) {
         Router.push(`/${username}/${reponame}/issues`)
-    } else {
-        Router.reload()
     }
 }
 

--- a/components/issueList.tsx
+++ b/components/issueList.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useState, MouseEventHandler } from 'react'
-import { useBottomScrollListener } from 'react-bottom-scroll-listener';
+import { useBottomScrollListener } from 'react-bottom-scroll-listener'
 
-import Link from 'next/link';
+import Link from 'next/link'
 
-import Button from './Button';
-import IssueCard from './IssueCard';
-import Loading from './Loading';
-import { WorkStatus } from '@/modules/WorkStatus';
+import { fetchRepoIssues } from './fetchGitHubApi'
+import Button from './Button'
+import IssueCard from './IssueCard'
+import Loading from './Loading'
+import { WorkStatus } from '@/modules/WorkStatus'
 
 type IssueListProps = {
     username: string;
@@ -41,24 +42,6 @@ const IssueList = (props: IssueListProps) => {
         return WorkStatus.NoLabel
     }
 
-    // Function to fetch the repository issues from Github API
-    const fetchRepoIssues = async () => {
-        setLoading(true)
-        fetch(`https://api.github.com/repos/${props.username}/${props.reponame}/issues?per_page=${page}`)
-            .then(response => response.json())
-            .then(data => {
-                // If number of issues received is less than the requested page, it means there are no more issues to be loaded
-                if (data.length < page) {
-                    setLoadMore(false)
-                }
-                // Updating the repository issues state with the received data
-                setRepoIssues(data)
-                setLoading(false)
-                console.log(`Load page ${pageCount}`, data)
-            })
-            .catch(error => console.error(error))
-    }
-
     // UseBottomScrollListener hook to detect when the user has scrolled to the bottom of the page
     useBottomScrollListener(() => {
         // If there are still issues to be loaded, increase the page count to load the next page
@@ -76,7 +59,7 @@ const IssueList = (props: IssueListProps) => {
 
     // UseEffect hook to fetch the repository issues when the page number changes
     useEffect(() => {
-        fetchRepoIssues()
+        fetchRepoIssues(props.username, props.reponame, page, setRepoIssues, setLoadMore, setLoading)
     }, [page])
 
     return (

--- a/components/repoList.tsx
+++ b/components/repoList.tsx
@@ -2,8 +2,9 @@ import { useEffect, useState, MouseEventHandler } from 'react'
 
 import Link from 'next/link'
 
+import { fetchRepos } from './fetchGitHubApi'
 import RepoCard from './RepoCard'
-import Loading from './Loading';
+import Loading from './Loading'
 
 type RepoListProps = {
     username: string;
@@ -18,28 +19,15 @@ const RepoList = (props: RepoListProps) => {
     const [repos, setRepos] = useState<Object[]>([])
     const [isLoading, setLoading] = useState(false)
 
-    // Asynchronously fetch the repositories for the given username
-    const fetchRepos = async () => {
-        setLoading(true)
-        fetch(`https://api.github.com/users/${props.username}/repos`)
-            .then(response => response.json())
-            .then(data => {
-                setRepos(data)
-                setLoading(false)
-            })
-            .catch(error => console.error(error))
-    }
-
     // Fetch the repos when the component is first mounted
     useEffect(() => {
-        fetchRepos()
+        fetchRepos(props.username, setRepos, setLoading)
     }, [])
 
     // If still loading, display a loading message
     if (isLoading) return (
         <Loading />
     )
-
 
     return (
         <div className={`${props.className} mt-3 gap-4 content-start`}>

--- a/pages/[username]/[reponame]/issues/[issue].tsx
+++ b/pages/[username]/[reponame]/issues/[issue].tsx
@@ -1,12 +1,13 @@
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react'
 
 import { GetServerSideProps, InferGetServerSidePropsType } from 'next'
 import { ParsedUrlQuery } from 'querystring'
 
-import IssueDetailCard from '@/components/IssueDetailCard';
-import Loading from '@/components/Loading';
-import { WorkStatus } from '@/modules/WorkStatus';
+import IssueDetailCard from '@/components/IssueDetailCard'
+import Loading from '@/components/Loading'
+import { fetchRepoIssue } from '@/components/fetchGitHubApi'
+import { WorkStatus } from '@/modules/WorkStatus'
 
 // Defining an interface for the URL parameters
 interface IParams extends ParsedUrlQuery {
@@ -27,31 +28,10 @@ const Issue = ({ username, reponame, issue }: InferGetServerSidePropsType<typeof
   const [workStatus, setWorkStatus] = useState(WorkStatus.NoLabel)
   const [isLoading, setLoading] = useState(false)
 
-  // Function to fetch the repository issues from Github API
-  const fetchRepoIssue = async () => {
-    setLoading(true)
-    fetch(`https://api.github.com/repos/${username}/${reponame}/issues/${issue}`)
-      .then(response => response.json())
-      .then(data => {
-        // Updating the repository issues state with the received data
-        setIssueData(data)
-        for (let label of data.labels) {
-          for (let key in label) {
-            if (key === 'name' && label[key] in WorkStatus) {
-              setWorkStatus(label[key])
-            }
-          }
-        }
-        setLoading(false)
-      })
-      .catch(error => console.error(error))
-  }
-
   // UseEffect hook to fetch the repository issues when the page number changes
   useEffect(() => {
-    fetchRepoIssue()
+    fetchRepoIssue(username, reponame, issue, setIssueData, setWorkStatus, setLoading)
   }, [])
-
 
   return (
     <>


### PR DESCRIPTION
**Descriptions**:
The purpose of this pull request is to change issue's work status label, currently the user can update specific issue in the issue detail page.
Screen shot:
![image](https://user-images.githubusercontent.com/79520786/218109117-4f2aa6fa-4f28-44d9-a3c7-20c1d7d3b796.png)


**Tests**:
Tested manually through exploratory testing.
Tested manually through hover over every elements.
Tested manually through click on every elements.

**Notes**:
Future work:
1.Edit issue in detail issue page (with input validation)
2.Create issue in issue list page
3.Order task in issue list page
4.Filter task in issue list page
5.Task Search in issue list page

Issue:
Can not update browser display in real-time after close the issue (Issue list page, issue detail page),
but Apis do work.