### PR TITLE
Feature/weiche filter task in issue list page and prev page button

### DIFF
--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -9,7 +9,7 @@ type ButtonProps = {
 const Button = (props: ButtonProps) => {
     return (
         <button
-            className={`p-2 rounded-md hover:ring-2 hover:ring-gray-300 ${props.className}`}
+            className={`p-2 rounded-md hover:ring-2 hover:ring-gray-300 dark:hover:ring-gray-700 ${props.className}`}
             onClick={props.onClick}>
             {props.children}
         </button>

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -9,7 +9,7 @@ type ButtonProps = {
 const Button = (props: ButtonProps) => {
     return (
         <button
-            className={`p-2 rounded-md hover:ring-2 hover:ring-gray-300 dark:hover:ring-gray-700 ${props.className}`}
+            className={`p-2 rounded-md hover:ring-2 hover:ring-gray-300 dark:hover:ring-gray-700 ease-in duration-300 ${props.className}`}
             onClick={props.onClick}>
             {props.children}
         </button>

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -9,7 +9,7 @@ type ButtonProps = {
 const Button = (props: ButtonProps) => {
     return (
         <button
-            className={`p-2 rounded-md hover:ring-2 hover:ring-gray-300 dark:hover:ring-gray-700 ease-in duration-300 ${props.className}`}
+            className={`p-2 text-sm rounded-md hover:ring-2 hover:ring-gray-300 dark:hover:ring-gray-700 ease-in duration-300 ${props.className}`}
             onClick={props.onClick}>
             {props.children}
         </button>

--- a/components/IssueDetailCard.tsx
+++ b/components/IssueDetailCard.tsx
@@ -1,10 +1,9 @@
 import { useEffect, useState } from 'react'
 
 import { useSession } from 'next-auth/react'
-import Router from 'next/router'
 import { ArrowLeftIcon } from '@heroicons/react/20/solid'
 
-import { updateIssue } from './fetchGitHubApi'
+import { updateIssue, hanedleBackButtonClick } from './fetchGitHubApi'
 import Button from './Button'
 import MoreOptionDropDown from './MoreOptionDropDown'
 import WorkStatusDropDown from './WorkStatusDropDown'
@@ -34,9 +33,7 @@ const IssueDetailCard = (props: IssueDetailCardProps) => {
         updateIssue(props.username, props.reponame, props.issue, token, ReqBody)
     }
 
-    const hanedleBackButtonClick = () => {
-        Router.back()
-    }
+
 
     return (
         <div className='m-2 bg-gray-200  dark:bg-gray-700 border dark:border-gray-700 rounded-lg'>

--- a/components/IssueDetailCard.tsx
+++ b/components/IssueDetailCard.tsx
@@ -41,7 +41,7 @@ const IssueDetailCard = (props: IssueDetailCardProps) => {
                 <div className='flex items-center justify-start'>
                     <div>
                         <Button
-                            className={'inline-flex w-full justify-center rounded-md border dark:border-gray-700 px-2 py-2 ease-in duration-300 bg-gray-200 text-black hover:bg-gray-300 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-500'}
+                            className={'inline-flex w-full justify-center rounded-md border dark:border-gray-700 px-2 py-2 bg-gray-200 text-black hover:bg-gray-300 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-500'}
                             onClick={hanedleBackButtonClick}>
                             <ArrowLeftIcon className="h-5 w-5" aria-hidden="true" />
                         </Button>

--- a/components/IssueDetailCard.tsx
+++ b/components/IssueDetailCard.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react'
 
 import { useSession } from 'next-auth/react'
+import Router from 'next/router'
+import { ArrowLeftIcon } from '@heroicons/react/20/solid'
 
 import { updateIssue } from './fetchGitHubApi'
 import Button from './Button'
@@ -32,17 +34,28 @@ const IssueDetailCard = (props: IssueDetailCardProps) => {
         updateIssue(props.username, props.reponame, props.issue, token, ReqBody)
     }
 
+    const hanedleBackButtonClick = () => {
+        Router.back()
+    }
+
     return (
         <div className='m-2 bg-gray-200  dark:bg-gray-700 border dark:border-gray-700 rounded-lg'>
             <div className='m-10 flex items-center justify-between'>
                 <div className='flex items-center justify-start'>
+                    <div>
+                        <Button
+                            className={'inline-flex w-full justify-center rounded-md border dark:border-gray-700 px-2 py-2 ease-in duration-300 bg-gray-200 text-black hover:bg-gray-300 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-500'}
+                            onClick={hanedleBackButtonClick}>
+                            <ArrowLeftIcon className="h-5 w-5" aria-hidden="true" />
+                        </Button>
+                    </div>
                     {props.state === 'open' &&
                         <WorkStatusDropDown workStatus={props.workStatus}
                             onOpenStatusButtonClick={() => { handleStatusButtonClick({ labels: [WorkStatus.Open] }) }}
                             onInProgressStatusButtonClick={() => { handleStatusButtonClick({ labels: [WorkStatus.InProgress] }) }}
                             onDoneStatusButtonClick={() => { handleStatusButtonClick({ labels: [WorkStatus.Done] }) }} />}
                     <div>
-                        {props.state === 'closed' && <Button className='mr-2 ease-in duration-300 bg-gray-300 text-black hover:bg-gray-500 hover:text-white px-6' onClick={() => { }}>Closed</Button>}
+                        {props.state === 'closed' && <Button className='ml-2 ease-in duration-300 bg-gray-300 text-black hover:bg-gray-500 hover:text-white px-6' onClick={() => { }}>Closed</Button>}
                     </div>
                 </div>
                 <MoreOptionDropDown onDeleteButtonClick={() => { handleStatusButtonClick({ state: 'closed' }) }} />

--- a/components/IssueDetailCard.tsx
+++ b/components/IssueDetailCard.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 import { useSession } from 'next-auth/react'
 import { ArrowLeftIcon } from '@heroicons/react/20/solid'
 
-import { updateIssue, hanedleBackButtonClick } from './fetchGitHubApi'
+import { updateIssue, handleBackButtonClick } from './fetchGitHubApi'
 import Button from './Button'
 import MoreOptionDropDown from './MoreOptionDropDown'
 import WorkStatusDropDown from './WorkStatusDropDown'
@@ -42,7 +42,7 @@ const IssueDetailCard = (props: IssueDetailCardProps) => {
                     <div>
                         <Button
                             className={'inline-flex w-full justify-center rounded-md border dark:border-gray-700 px-2 py-2 bg-gray-200 text-black hover:bg-gray-300 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-500'}
-                            onClick={hanedleBackButtonClick}>
+                            onClick={handleBackButtonClick}>
                             <ArrowLeftIcon className="h-5 w-5" aria-hidden="true" />
                         </Button>
                     </div>

--- a/components/MoreOptionDropDown.tsx
+++ b/components/MoreOptionDropDown.tsx
@@ -13,7 +13,7 @@ const MoreOptionDropDown = (props: MoreOptionDropDownProps) => {
     return (
         <Menu as="div" className="relative inline-block text-left">
             <div>
-                <Menu.Button className="inline-flex w-full justify-center rounded-md border dark:border-gray-700 px-4 py-2 ease-in duration-300 bg-gray-200 text-black hover:bg-gray-300 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-500">
+                <Menu.Button className="inline-flex w-full justify-center rounded-md border dark:border-gray-700 px-2 py-2 ease-in duration-300 bg-gray-200 text-black hover:bg-gray-300 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-500">
                     <EllipsisVerticalIcon className="h-5 w-5" aria-hidden="true" />
                 </Menu.Button>
             </div>

--- a/components/WorkStatusDropDown.tsx
+++ b/components/WorkStatusDropDown.tsx
@@ -20,19 +20,19 @@ const WorkStatusDropDown = (props: WorkStatusDropDownProps) => {
 
     switch (props.workStatus) {
         case WorkStatus.Open: {
-            menuButtonClass = 'inline-flex w-full justify-center rounded-md hover:ring-2 hover:ring-gray-300  bg-blue-300 px-4 py-2 text-sm font-medium text-black shadow-sm hover:bg-blue-500 hover:text-white focus:outline-none focus:ring-2 ease-in duration-300'
+            menuButtonClass = 'inline-flex w-full justify-center rounded-md hover:ring-2 hover:ring-gray-300 dark:hover:ring-gray-700 bg-blue-300 px-4 py-2 text-sm font-medium text-black shadow-sm hover:bg-blue-500 hover:text-white focus:outline-none focus:ring-2 ease-in duration-300'
             break;
         }
         case WorkStatus.InProgress: {
-            menuButtonClass = 'inline-flex w-full justify-center rounded-md hover:ring-2 hover:ring-gray-300  bg-red-300 px-4 py-2 text-sm font-medium text-black shadow-sm hover:bg-red-500 hover:text-white focus:outline-none focus:ring-2 ease-in duration-300'
+            menuButtonClass = 'inline-flex w-full justify-center rounded-md hover:ring-2 hover:ring-gray-300 dark:hover:ring-gray-700 bg-red-300 px-4 py-2 text-sm font-medium text-black shadow-sm hover:bg-red-500 hover:text-white focus:outline-none focus:ring-2 ease-in duration-300'
             break;
         }
         case WorkStatus.Done: {
-            menuButtonClass = 'inline-flex w-full justify-center rounded-md hover:ring-2 hover:ring-gray-300  bg-green-300 px-4 py-2 text-sm font-medium text-black shadow-sm hover:bg-green-500 hover:text-white focus:outline-none focus:ring-2 ease-in duration-300'
+            menuButtonClass = 'inline-flex w-full justify-center rounded-md hover:ring-2 hover:ring-gray-300 dark:hover:ring-gray-700 bg-green-300 px-4 py-2 text-sm font-medium text-black shadow-sm hover:bg-green-500 hover:text-white focus:outline-none focus:ring-2 ease-in duration-300'
             break;
         }
         default: {
-            menuButtonClass = 'inline-flex w-full justify-center rounded-md hover:ring-2 hover:ring-gray-300  bg-gray-300 px-4 py-2 text-sm font-medium text-black shadow-sm hover:bg-gray-500 hover:text-white focus:outline-none focus:ring-2 ease-in duration-300'
+            menuButtonClass = 'inline-flex w-full justify-center rounded-md hover:ring-2 hover:ring-gray-300 dark:hover:ring-gray-700 bg-gray-300 px-4 py-2 text-sm font-medium text-black shadow-sm hover:bg-gray-500 hover:text-white focus:outline-none focus:ring-2 ease-in duration-300'
             break;
         }
     }

--- a/components/WorkStatusDropDown.tsx
+++ b/components/WorkStatusDropDown.tsx
@@ -39,7 +39,7 @@ const WorkStatusDropDown = (props: WorkStatusDropDownProps) => {
 
     return (
         <Menu as="div" className="relative inline-block text-left">
-            <div>
+            <div className='ml-2'>
                 <Menu.Button className={menuButtonClass}>
                     {props.workStatus}
                     <ChevronDownIcon className="-mr-1 ml-2 h-5 w-5" aria-hidden="true" />

--- a/components/fetchGitHubApi.tsx
+++ b/components/fetchGitHubApi.tsx
@@ -34,9 +34,9 @@ export const fetchRepos = async (username: string, setData: any, setLoading: any
 }
 
 // Function to fetch the repository issues from Github API, ref in file issueList.tsx
-export const fetchRepoIssues = async (username: string, reponame: string, page: number, setData: any, setLoadMore: any, setLoading: any) => {
+export const fetchRepoIssues = async (username: string, reponame: string, page: number, labels: string, setData: any, setLoadMore: any, setLoading: any) => {
     setLoading(true)
-    fetch(`https://api.github.com/repos/${username}/${reponame}/issues?per_page=${page}`)
+    fetch(`https://api.github.com/repos/${username}/${reponame}/issues?per_page=${page}&labels=${labels}`)
         .then(response => response.json())
         .then(data => {
             // If number of issues received is less than the requested page, it means there are no more issues to be loaded
@@ -69,6 +69,6 @@ export const updateIssue = async (username: string, reponame: string, issue: num
     }
 }
 
-export const hanedleBackButtonClick = () => {
+export const handleBackButtonClick = () => {
     Router.back()
 }

--- a/components/fetchGitHubApi.tsx
+++ b/components/fetchGitHubApi.tsx
@@ -69,3 +69,6 @@ export const updateIssue = async (username: string, reponame: string, issue: num
     }
 }
 
+export const hanedleBackButtonClick = () => {
+    Router.back()
+}

--- a/components/fetchGitHubApi.tsx
+++ b/components/fetchGitHubApi.tsx
@@ -46,7 +46,6 @@ export const fetchRepoIssues = async (username: string, reponame: string, page: 
             // Updating the repository issues state with the received data
             setData(data)
             setLoading(false)
-            console.log(`Load page ${page / 10}`, data)
         })
         .catch(error => console.error(error))
 }

--- a/components/issueList.tsx
+++ b/components/issueList.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState, MouseEventHandler } from 'react'
 import { useBottomScrollListener } from 'react-bottom-scroll-listener'
 
 import Link from 'next/link'
+import Router from 'next/router'
+import { ArrowLeftIcon } from '@heroicons/react/20/solid'
 
 import { fetchRepoIssues } from './fetchGitHubApi'
 import Button from './Button'
@@ -62,10 +64,21 @@ const IssueList = (props: IssueListProps) => {
         fetchRepoIssues(props.username, props.reponame, page, setRepoIssues, setLoadMore, setLoading)
     }, [page])
 
+    const hanedleBackButtonClick = () => {
+        Router.back()
+    }
+
     return (
         <div className={`${props.className} mt-3`}>
             <div className='mt-10 mb-5 flex flex-row items-center justify-between'>
                 <div className='flex items-center justify-left '>
+                    <div>
+                        <Button
+                            className={'ease-in duration-300 ml-2 bg-gray-300 text-black hover:bg-gray-500 hover:text-white px-2 py-2'}
+                            onClick={hanedleBackButtonClick}>
+                            <ArrowLeftIcon className="h-5 w-5" aria-hidden="true" />
+                        </Button>
+                    </div>
                     <Button className='ease-in duration-300 ml-2 bg-blue-300 text-black hover:bg-blue-500 hover:text-white px-6' onClick={() => { }}>Open</Button>
                     <Button className='ease-in duration-300 ml-2 bg-red-300 text-black hover:bg-red-500 hover:text-white px-6' onClick={() => { }}>In Progress</Button>
                     <Button className='ease-in duration-300 ml-2 bg-green-300 text-black hover:bg-green-500 hover:text-white px-6' onClick={() => { }}>Done</Button>

--- a/components/issueList.tsx
+++ b/components/issueList.tsx
@@ -2,13 +2,14 @@ import { useEffect, useState, MouseEventHandler } from 'react'
 import { useBottomScrollListener } from 'react-bottom-scroll-listener'
 
 import Link from 'next/link'
-import { ArrowLeftIcon } from '@heroicons/react/20/solid'
+import { ArrowLeftIcon, AdjustmentsHorizontalIcon, ChevronDownIcon } from '@heroicons/react/20/solid'
 
 import { fetchRepoIssues, handleBackButtonClick } from './fetchGitHubApi'
 import Button from './Button'
 import IssueCard from './IssueCard'
 import Loading from './Loading'
 import { WorkStatus } from '@/modules/WorkStatus'
+import WorkStatusDropDown from './WorkStatusDropDown'
 
 type IssueListProps = {
     username: string;
@@ -44,7 +45,9 @@ const IssueList = (props: IssueListProps) => {
         return WorkStatus.NoLabel
     }
 
-    //const handleFilterButtonClick = () => { }
+    const handleFilterButtonClick = (label: string) => {
+        setLabels(label)
+    }
 
     // UseBottomScrollListener hook to detect when the user has scrolled to the bottom of the page
     useBottomScrollListener(() => {
@@ -69,7 +72,8 @@ const IssueList = (props: IssueListProps) => {
 
     return (
         <div className={`${props.className} mt-3`}>
-            <div className='mt-10 mb-5 flex flex-row items-center justify-between'>
+
+            <div className='mt-10 flex flex-row items-center justify-between'>
                 <div className='flex items-center justify-left '>
                     <div>
                         <Button
@@ -78,15 +82,39 @@ const IssueList = (props: IssueListProps) => {
                             <ArrowLeftIcon className="h-5 w-5" aria-hidden="true" />
                         </Button>
                     </div>
-                    <Button className='ml-2 bg-blue-300 text-black hover:bg-blue-500 hover:text-white px-6' onClick={() => { }}>Open</Button>
-                    <Button className='ml-2 bg-red-300 text-black hover:bg-red-500 hover:text-white px-6' onClick={() => { }}>In Progress</Button>
-                    <Button className='ml-2 bg-green-300 text-black hover:bg-green-500 hover:text-white px-6' onClick={() => { }}>Done</Button>
+
                 </div>
-                <div className='flex items-center justify-left '>
-                    <Button className='ml-2 bg-gray-300 text-black hover:bg-gray-500 hover:text-white px-6' onClick={() => { }}>Order</Button>
-                    <Button className='ml-2 bg-yellow-300 text-black hover:bg-yellow-500 hover:text-white px-6' onClick={() => { }}>Create Issue</Button>
+                <div className='flex items-center justify-left'>
+                    <Button className='ml-2 bg-yellow-300 text-black hover:bg-yellow-500 hover:text-white px-6 py-2 ' onClick={() => { }}>Create Issue</Button>
                 </div>
             </div>
+
+            <div className='mt-2 mb-5 flex flex-row items-center justify-between'>
+                <div className='flex items-center justify-left'>
+                    <WorkStatusDropDown workStatus={labels === '' ? 'Filter' : labels}
+                        onOpenStatusButtonClick={() => { handleFilterButtonClick(WorkStatus.Open) }}
+                        onInProgressStatusButtonClick={() => { handleFilterButtonClick(WorkStatus.InProgress) }}
+                        onDoneStatusButtonClick={() => { handleFilterButtonClick(WorkStatus.Done) }}
+                    />
+                    <Button
+                        className='ml-2 inline-flex w-full justify-center rounded-md hover:ring-2 hover:ring-gray-300 dark:hover:ring-gray-700 bg-gray-300 px-4 py-2 text-sm font-medium text-black shadow-sm hover:bg-gray-500 hover:text-white focus:outline-none focus:ring-2'
+                        onClick={() => { }}>
+                        Order
+                        <ChevronDownIcon className="-mr-1 ml-2 h-5 w-5" aria-hidden="true" />
+                    </Button>
+                    <Button
+                        className={'ml-2 bg-gray-300 text-black hover:bg-gray-500 hover:text-white px-6 py-2 flex flex-row justify-start items-center w-full text-left text-sm'}
+                        onClick={() => { handleFilterButtonClick('') }}>
+                        <AdjustmentsHorizontalIcon className="h-5 w-5 mr-2" aria-hidden="true" />
+                        Reset 
+                    </Button>
+                </div>
+                <div className='flex items-center justify-left'>
+                    <input className="shadow appearance-none border border-gray-200 dark:border-gray-700 rounded w-full py-1 px-3 text-gray-700 dark:text-gray-300 leading-tight focus:outline-none focus:shadow-outline" id="search" type="text" placeholder="Search"></input>
+                    <Button className='ml-2 bg-blue-300 text-black hover:bg-blue-500 hover:text-white px-6' onClick={() => { }}>Search</Button>
+                </div>
+            </div>
+
             {repoIssues.map((issue: any, i: number) => (
                 <Link legacyBehavior href={`/${props.username}/${props.reponame}/issues/${issue.number}`} className='' key={'link' + i}>
                     <div>

--- a/components/issueList.tsx
+++ b/components/issueList.tsx
@@ -4,7 +4,7 @@ import { useBottomScrollListener } from 'react-bottom-scroll-listener'
 import Link from 'next/link'
 import { ArrowLeftIcon } from '@heroicons/react/20/solid'
 
-import { fetchRepoIssues, hanedleBackButtonClick } from './fetchGitHubApi'
+import { fetchRepoIssues, handleBackButtonClick } from './fetchGitHubApi'
 import Button from './Button'
 import IssueCard from './IssueCard'
 import Loading from './Loading'
@@ -27,6 +27,7 @@ const IssueList = (props: IssueListProps) => {
     // State variables to keep track of the page number and issues loaded
     const [pageCount, setPageCount] = useState<number>(1)
     const [page, setPage] = useState<number>(PER_PAGE * pageCount)
+    const [labels, setLabels] = useState<string>('')
     const [repoIssues, setRepoIssues] = useState<Object[]>([])
     const [isLoading, setLoading] = useState(false)
     const [loadMore, setLoadMore] = useState<boolean>(true)
@@ -42,6 +43,8 @@ const IssueList = (props: IssueListProps) => {
         }
         return WorkStatus.NoLabel
     }
+
+    //const handleFilterButtonClick = () => { }
 
     // UseBottomScrollListener hook to detect when the user has scrolled to the bottom of the page
     useBottomScrollListener(() => {
@@ -60,8 +63,8 @@ const IssueList = (props: IssueListProps) => {
 
     // UseEffect hook to fetch the repository issues when the page number changes
     useEffect(() => {
-        fetchRepoIssues(props.username, props.reponame, page, setRepoIssues, setLoadMore, setLoading)
-    }, [page])
+        fetchRepoIssues(props.username, props.reponame, page, labels, setRepoIssues, setLoadMore, setLoading)
+    }, [page, labels])
 
 
     return (
@@ -71,7 +74,7 @@ const IssueList = (props: IssueListProps) => {
                     <div>
                         <Button
                             className={'ml-2 bg-gray-300 text-black hover:bg-gray-500 hover:text-white px-2 py-2'}
-                            onClick={hanedleBackButtonClick}>
+                            onClick={handleBackButtonClick}>
                             <ArrowLeftIcon className="h-5 w-5" aria-hidden="true" />
                         </Button>
                     </div>

--- a/components/issueList.tsx
+++ b/components/issueList.tsx
@@ -70,18 +70,18 @@ const IssueList = (props: IssueListProps) => {
                 <div className='flex items-center justify-left '>
                     <div>
                         <Button
-                            className={'ease-in duration-300 ml-2 bg-gray-300 text-black hover:bg-gray-500 hover:text-white px-2 py-2'}
+                            className={'ml-2 bg-gray-300 text-black hover:bg-gray-500 hover:text-white px-2 py-2'}
                             onClick={hanedleBackButtonClick}>
                             <ArrowLeftIcon className="h-5 w-5" aria-hidden="true" />
                         </Button>
                     </div>
-                    <Button className='ease-in duration-300 ml-2 bg-blue-300 text-black hover:bg-blue-500 hover:text-white px-6' onClick={() => { }}>Open</Button>
-                    <Button className='ease-in duration-300 ml-2 bg-red-300 text-black hover:bg-red-500 hover:text-white px-6' onClick={() => { }}>In Progress</Button>
-                    <Button className='ease-in duration-300 ml-2 bg-green-300 text-black hover:bg-green-500 hover:text-white px-6' onClick={() => { }}>Done</Button>
+                    <Button className='ml-2 bg-blue-300 text-black hover:bg-blue-500 hover:text-white px-6' onClick={() => { }}>Open</Button>
+                    <Button className='ml-2 bg-red-300 text-black hover:bg-red-500 hover:text-white px-6' onClick={() => { }}>In Progress</Button>
+                    <Button className='ml-2 bg-green-300 text-black hover:bg-green-500 hover:text-white px-6' onClick={() => { }}>Done</Button>
                 </div>
                 <div className='flex items-center justify-left '>
-                    <Button className='ease-in duration-300 ml-2 bg-gray-300 text-black hover:bg-gray-500 hover:text-white px-6' onClick={() => { }}>Order</Button>
-                    <Button className='ease-in duration-300 ml-2 bg-yellow-300 text-black hover:bg-yellow-500 hover:text-white px-6' onClick={() => { }}>Create Issue</Button>
+                    <Button className='ml-2 bg-gray-300 text-black hover:bg-gray-500 hover:text-white px-6' onClick={() => { }}>Order</Button>
+                    <Button className='ml-2 bg-yellow-300 text-black hover:bg-yellow-500 hover:text-white px-6' onClick={() => { }}>Create Issue</Button>
                 </div>
             </div>
             {repoIssues.map((issue: any, i: number) => (

--- a/components/issueList.tsx
+++ b/components/issueList.tsx
@@ -2,10 +2,9 @@ import { useEffect, useState, MouseEventHandler } from 'react'
 import { useBottomScrollListener } from 'react-bottom-scroll-listener'
 
 import Link from 'next/link'
-import Router from 'next/router'
 import { ArrowLeftIcon } from '@heroicons/react/20/solid'
 
-import { fetchRepoIssues } from './fetchGitHubApi'
+import { fetchRepoIssues, hanedleBackButtonClick } from './fetchGitHubApi'
 import Button from './Button'
 import IssueCard from './IssueCard'
 import Loading from './Loading'
@@ -64,9 +63,6 @@ const IssueList = (props: IssueListProps) => {
         fetchRepoIssues(props.username, props.reponame, page, setRepoIssues, setLoadMore, setLoading)
     }, [page])
 
-    const hanedleBackButtonClick = () => {
-        Router.back()
-    }
 
     return (
         <div className={`${props.className} mt-3`}>

--- a/components/repoList.tsx
+++ b/components/repoList.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState, MouseEventHandler } from 'react'
 
 import Link from 'next/link'
+import { ArrowLeftIcon, ChevronDownIcon } from '@heroicons/react/20/solid'
 
 import { fetchRepos, handleBackButtonClick } from './fetchGitHubApi'
 import RepoCard from './RepoCard'
 import Loading from './Loading'
 import Button from './Button'
-import { ArrowLeftIcon } from '@heroicons/react/20/solid'
 
 type RepoListProps = {
     username: string;
@@ -34,21 +34,22 @@ const RepoList = (props: RepoListProps) => {
     return (
         <div className={`${props.className} mt-3 gap-4 content-start`}>
             <div className='mt-10 mb-5 flex flex-row items-center justify-between'>
-                <div className='flex items-center justify-left '>
-                    <div>
-                        <Button
-                            className={'ml-2 bg-gray-300 text-black hover:bg-gray-500 hover:text-white px-2 py-2'}
-                            onClick={handleBackButtonClick}>
-                            <ArrowLeftIcon className="h-5 w-5" aria-hidden="true" />
-                        </Button>
-                    </div>
-                    <Button className='ml-2 bg-blue-300 text-black hover:bg-blue-500 hover:text-white px-6' onClick={() => { }}>Open</Button>
-                    <Button className='ml-2 bg-red-300 text-black hover:bg-red-500 hover:text-white px-6' onClick={() => { }}>In Progress</Button>
-                    <Button className='ml-2 bg-green-300 text-black hover:bg-green-500 hover:text-white px-6' onClick={() => { }}>Done</Button>
+                <div className='flex items-center justify-left'>
+                    <Button
+                        className={'ml-2 bg-gray-300 text-black hover:bg-gray-500 hover:text-white px-2 py-2'}
+                        onClick={handleBackButtonClick}>
+                        <ArrowLeftIcon className="h-5 w-5" aria-hidden="true" />
+                    </Button>
+                    <Button
+                        className='ml-2 inline-flex w-full justify-center rounded-md hover:ring-2 hover:ring-gray-300 dark:hover:ring-gray-700 bg-gray-300 px-4 py-2 text-sm font-medium text-black shadow-sm hover:bg-gray-500 hover:text-white focus:outline-none focus:ring-2'
+                        onClick={() => { }}>
+                        Order
+                        <ChevronDownIcon className="-mr-1 ml-2 h-5 w-5" aria-hidden="true" />
+                    </Button>
                 </div>
                 <div className='flex items-center justify-left '>
-                    <Button className='ml-2 bg-gray-300 text-black hover:bg-gray-500 hover:text-white px-6' onClick={() => { }}>Order</Button>
-                    <Button className='ml-2 bg-yellow-300 text-black hover:bg-yellow-500 hover:text-white px-6' onClick={() => { }}>Create Issue</Button>
+                    <input className="shadow appearance-none border border-gray-200 dark:border-gray-700 rounded w-full py-1 px-3 text-gray-700 dark:text-gray-300 leading-tight focus:outline-none focus:shadow-outline" id="search" type="text" placeholder="Search"></input>
+                    <Button className='ml-2 bg-blue-300 text-black hover:bg-blue-500 hover:text-white px-6' onClick={() => { }}>Search</Button>
                 </div>
             </div>
             {repos.map((repo: any, i) => (

--- a/components/repoList.tsx
+++ b/components/repoList.tsx
@@ -2,9 +2,11 @@ import { useEffect, useState, MouseEventHandler } from 'react'
 
 import Link from 'next/link'
 
-import { fetchRepos } from './fetchGitHubApi'
+import { fetchRepos, hanedleBackButtonClick } from './fetchGitHubApi'
 import RepoCard from './RepoCard'
 import Loading from './Loading'
+import Button from './Button'
+import { ArrowLeftIcon } from '@heroicons/react/20/solid'
 
 type RepoListProps = {
     username: string;
@@ -31,6 +33,24 @@ const RepoList = (props: RepoListProps) => {
 
     return (
         <div className={`${props.className} mt-3 gap-4 content-start`}>
+            <div className='mt-10 mb-5 flex flex-row items-center justify-between'>
+                <div className='flex items-center justify-left '>
+                    <div>
+                        <Button
+                            className={'ease-in duration-300 ml-2 bg-gray-300 text-black hover:bg-gray-500 hover:text-white px-2 py-2'}
+                            onClick={hanedleBackButtonClick}>
+                            <ArrowLeftIcon className="h-5 w-5" aria-hidden="true" />
+                        </Button>
+                    </div>
+                    <Button className='ease-in duration-300 ml-2 bg-blue-300 text-black hover:bg-blue-500 hover:text-white px-6' onClick={() => { }}>Open</Button>
+                    <Button className='ease-in duration-300 ml-2 bg-red-300 text-black hover:bg-red-500 hover:text-white px-6' onClick={() => { }}>In Progress</Button>
+                    <Button className='ease-in duration-300 ml-2 bg-green-300 text-black hover:bg-green-500 hover:text-white px-6' onClick={() => { }}>Done</Button>
+                </div>
+                <div className='flex items-center justify-left '>
+                    <Button className='ease-in duration-300 ml-2 bg-gray-300 text-black hover:bg-gray-500 hover:text-white px-6' onClick={() => { }}>Order</Button>
+                    <Button className='ease-in duration-300 ml-2 bg-yellow-300 text-black hover:bg-yellow-500 hover:text-white px-6' onClick={() => { }}>Create Issue</Button>
+                </div>
+            </div>
             {repos.map((repo: any, i) => (
                 <Link legacyBehavior href={`/${props.username}/${repo.name}/issues`} passHref className='' key={'link' + i}>
                     <div>

--- a/components/repoList.tsx
+++ b/components/repoList.tsx
@@ -37,18 +37,18 @@ const RepoList = (props: RepoListProps) => {
                 <div className='flex items-center justify-left '>
                     <div>
                         <Button
-                            className={'ease-in duration-300 ml-2 bg-gray-300 text-black hover:bg-gray-500 hover:text-white px-2 py-2'}
+                            className={'ml-2 bg-gray-300 text-black hover:bg-gray-500 hover:text-white px-2 py-2'}
                             onClick={hanedleBackButtonClick}>
                             <ArrowLeftIcon className="h-5 w-5" aria-hidden="true" />
                         </Button>
                     </div>
-                    <Button className='ease-in duration-300 ml-2 bg-blue-300 text-black hover:bg-blue-500 hover:text-white px-6' onClick={() => { }}>Open</Button>
-                    <Button className='ease-in duration-300 ml-2 bg-red-300 text-black hover:bg-red-500 hover:text-white px-6' onClick={() => { }}>In Progress</Button>
-                    <Button className='ease-in duration-300 ml-2 bg-green-300 text-black hover:bg-green-500 hover:text-white px-6' onClick={() => { }}>Done</Button>
+                    <Button className='ml-2 bg-blue-300 text-black hover:bg-blue-500 hover:text-white px-6' onClick={() => { }}>Open</Button>
+                    <Button className='ml-2 bg-red-300 text-black hover:bg-red-500 hover:text-white px-6' onClick={() => { }}>In Progress</Button>
+                    <Button className='ml-2 bg-green-300 text-black hover:bg-green-500 hover:text-white px-6' onClick={() => { }}>Done</Button>
                 </div>
                 <div className='flex items-center justify-left '>
-                    <Button className='ease-in duration-300 ml-2 bg-gray-300 text-black hover:bg-gray-500 hover:text-white px-6' onClick={() => { }}>Order</Button>
-                    <Button className='ease-in duration-300 ml-2 bg-yellow-300 text-black hover:bg-yellow-500 hover:text-white px-6' onClick={() => { }}>Create Issue</Button>
+                    <Button className='ml-2 bg-gray-300 text-black hover:bg-gray-500 hover:text-white px-6' onClick={() => { }}>Order</Button>
+                    <Button className='ml-2 bg-yellow-300 text-black hover:bg-yellow-500 hover:text-white px-6' onClick={() => { }}>Create Issue</Button>
                 </div>
             </div>
             {repos.map((repo: any, i) => (

--- a/components/repoList.tsx
+++ b/components/repoList.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, MouseEventHandler } from 'react'
 
 import Link from 'next/link'
 
-import { fetchRepos, hanedleBackButtonClick } from './fetchGitHubApi'
+import { fetchRepos, handleBackButtonClick } from './fetchGitHubApi'
 import RepoCard from './RepoCard'
 import Loading from './Loading'
 import Button from './Button'
@@ -38,7 +38,7 @@ const RepoList = (props: RepoListProps) => {
                     <div>
                         <Button
                             className={'ml-2 bg-gray-300 text-black hover:bg-gray-500 hover:text-white px-2 py-2'}
-                            onClick={hanedleBackButtonClick}>
+                            onClick={handleBackButtonClick}>
                             <ArrowLeftIcon className="h-5 w-5" aria-hidden="true" />
                         </Button>
                     </div>

--- a/sections/IndexBody.tsx
+++ b/sections/IndexBody.tsx
@@ -22,9 +22,9 @@ const IndexBody = () => {
                 and update the status of Task.
             </p>
             <div className='flex items-center justify-between'>
-                {!session && <Button className='ease-in duration-300 bg-blue-500 text-white px-6' onClick={() => signIn()}>Login</Button>}
-                {session && <Button className='ease-in duration-300 bg-blue-500 text-white px-6' onClick={directToReposPage}>Start</Button>}
-                {session && <Button className='ease-in duration-300 bg-red-500 text-white px-6' onClick={() => signOut()}>Logout</Button>}
+                {!session && <Button className='bg-blue-300 text-black hover:bg-blue-500 hover:text-white px-6' onClick={() => signIn()}>Login</Button>}
+                {session && <Button className='bg-blue-300 text-black hover:bg-blue-500 hover:text-white px-6' onClick={directToReposPage}>Start</Button>}
+                {session && <Button className='bg-red-300 text-black hover:bg-blue-500 hover:text-white px-6' onClick={() => signOut()}>Logout</Button>}
             </div>
         </section>
     )


### PR DESCRIPTION
**Descriptions**:
The aim of this pull request is to enable users to filter issues by work status labels on the issue list page and add a reset button to clear the filter.
Screen shot:
![image](https://user-images.githubusercontent.com/79520786/218146457-8789673b-d64b-4a65-bef5-25ee755d8258.png)

**Tests**:
Tested manually through exploratory testing.
Tested manually through hover over every elements.
Tested manually through click on every elements.

**Notes**:
Future work:
1.Edit issue in detail issue page (with input validation)
2.Create issue in issue list page
3.Order task in issue list page
4.Task Search in issue list page

Issue:
Can not update browser display in real-time after close the issue (Issue list page, issue detail page),
but Apis do work.