### PR TITLE
Feature/weiche sort in issue list page

### DIFF
--- a/components/IssueCard.tsx
+++ b/components/IssueCard.tsx
@@ -7,11 +7,13 @@ type IssueCardProps = {
     title: string;
     body: string;
     workStatus: string;
+    createdAt: string;
     className: string;
     onClick: MouseEventHandler;
 }
 
 const IssueCard = (props: IssueCardProps) => {
+    const createdAt = new Date(props.createdAt).toString()
     return (
         <a onClick={props.onClick} className={`${props.className} ease-in duration-300 block p-6 bg-white border border-gray-200 rounded-lg shadow hover:bg-gray-100 dark:bg-gray-800 dark:border-gray-700 dark:hover:bg-gray-700`}>
             <div className='flex flex-row justify-between'>
@@ -21,7 +23,8 @@ const IssueCard = (props: IssueCardProps) => {
                 {props.workStatus === WorkStatus.Done && <h6 className="mb-2 text-green-500 dark:text-green-300 tracking-tight">{props.workStatus}</h6>}
                 {props.workStatus === WorkStatus.NoLabel && <h6 className="mb-2 text-gray-500 dark:text-gray-300 tracking-tight">{props.workStatus}</h6>}
             </div>
-            <p className="font-normal text-gray-700 dark:text-gray-400">{props.body}</p>
+            <h6 className="font-normal text-gray-800 dark:text-gray-300">{props.body}</h6>
+            <p className="font-normal text-gray-700 dark:text-gray-400">Created at {createdAt}</p>
         </a>
     )
 }

--- a/components/fetchGitHubApi.tsx
+++ b/components/fetchGitHubApi.tsx
@@ -34,9 +34,9 @@ export const fetchRepos = async (username: string, setData: any, setLoading: any
 }
 
 // Function to fetch the repository issues from Github API, ref in file issueList.tsx
-export const fetchRepoIssues = async (username: string, reponame: string, page: number, labels: string, setData: any, setLoadMore: any, setLoading: any) => {
+export const fetchRepoIssues = async (username: string, reponame: string, page: number, labels: string, sort: any, direction: any, setData: any, setLoadMore: any, setLoading: any) => {
     setLoading(true)
-    fetch(`https://api.github.com/repos/${username}/${reponame}/issues?per_page=${page}&labels=${labels}`)
+    fetch(`https://api.github.com/repos/${username}/${reponame}/issues?per_page=${page}&labels=${labels}&sort=${sort}&direction=${direction}`)
         .then(response => response.json())
         .then(data => {
             // If number of issues received is less than the requested page, it means there are no more issues to be loaded

--- a/components/issueList.tsx
+++ b/components/issueList.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, MouseEventHandler } from 'react'
 import { useBottomScrollListener } from 'react-bottom-scroll-listener'
 
 import Link from 'next/link'
-import { ArrowLeftIcon, AdjustmentsHorizontalIcon, ChevronDownIcon } from '@heroicons/react/20/solid'
+import { ArrowLeftIcon, AdjustmentsHorizontalIcon, ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/20/solid'
 
 import { fetchRepoIssues, handleBackButtonClick } from './fetchGitHubApi'
 import Button from './Button'
@@ -32,6 +32,8 @@ const IssueList = (props: IssueListProps) => {
     const [repoIssues, setRepoIssues] = useState<Object[]>([])
     const [isLoading, setLoading] = useState(false)
     const [loadMore, setLoadMore] = useState<boolean>(true)
+    const [sort, setSort] = useState('created') // created, updated, comments
+    const [direction, setDirection] = useState('desc') // asc, desc
 
     const getWorkStatus = (labels: []) => {
         for (let label of labels) {
@@ -47,6 +49,15 @@ const IssueList = (props: IssueListProps) => {
 
     const handleFilterButtonClick = (label: string) => {
         setLabels(label)
+    }
+
+    const handleSortButtonClick = () => {
+        setDirection(direction === 'desc' ? 'asc' : 'desc')
+    }
+
+    const handleResetButtonClick = () => {
+        handleFilterButtonClick('')
+        setDirection('desc')
     }
 
     // UseBottomScrollListener hook to detect when the user has scrolled to the bottom of the page
@@ -66,8 +77,8 @@ const IssueList = (props: IssueListProps) => {
 
     // UseEffect hook to fetch the repository issues when the page number changes
     useEffect(() => {
-        fetchRepoIssues(props.username, props.reponame, page, labels, setRepoIssues, setLoadMore, setLoading)
-    }, [page, labels])
+        fetchRepoIssues(props.username, props.reponame, page, labels, sort, direction, setRepoIssues, setLoadMore, setLoading)
+    }, [page, labels, direction])
 
 
     return (
@@ -98,13 +109,14 @@ const IssueList = (props: IssueListProps) => {
                     />
                     <Button
                         className='ml-2 inline-flex w-full justify-center rounded-md hover:ring-2 hover:ring-gray-300 dark:hover:ring-gray-700 bg-gray-300 px-4 py-2 text-sm font-medium text-black shadow-sm hover:bg-gray-500 hover:text-white focus:outline-none focus:ring-2'
-                        onClick={() => { }}>
+                        onClick={() => { handleSortButtonClick() }}>
                         Order
-                        <ChevronDownIcon className="-mr-1 ml-2 h-5 w-5" aria-hidden="true" />
+                        {direction === 'desc' && <ChevronDownIcon className="-mr-1 ml-2 h-5 w-5" aria-hidden="true" />}
+                        {direction === 'asc' && <ChevronUpIcon className="-mr-1 ml-2 h-5 w-5" aria-hidden="true" />}
                     </Button>
                     <Button
                         className={'ml-2 bg-gray-300 text-black hover:bg-gray-500 hover:text-white px-6 py-2 flex flex-row justify-start items-center w-full text-left text-sm'}
-                        onClick={() => { handleFilterButtonClick('') }}>
+                        onClick={() => { handleResetButtonClick() }}>
                         <AdjustmentsHorizontalIcon className="h-5 w-5 mr-2" aria-hidden="true" />
                         Reset
                     </Button>

--- a/components/issueList.tsx
+++ b/components/issueList.tsx
@@ -78,6 +78,7 @@ const IssueList = (props: IssueListProps) => {
     // UseEffect hook to fetch the repository issues when the page number changes
     useEffect(() => {
         fetchRepoIssues(props.username, props.reponame, page, labels, sort, direction, setRepoIssues, setLoadMore, setLoading)
+        console.log(repoIssues)
     }, [page, labels, direction])
 
 
@@ -130,7 +131,9 @@ const IssueList = (props: IssueListProps) => {
             {repoIssues.map((issue: any, i: number) => (
                 <Link legacyBehavior href={`/${props.username}/${props.reponame}/issues/${issue.number}`} className='' key={'link' + i}>
                     <div>
-                        <IssueCard number={issue.number} title={issue.title} body={issue.body} workStatus={getWorkStatus(issue.labels)!} className='mt-2' onClick={() => { }} key={i} />
+                        <IssueCard number={issue.number} title={issue.title} body={issue.body}
+                            workStatus={getWorkStatus(issue.labels)!} createdAt={issue.created_at}
+                            className='mt-2' onClick={() => { }} key={i} />
                     </div>
                 </Link>
             ))}

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -47,8 +47,8 @@ const About = () => {
             <ul className="mt-1 list-disc">
                 <li>第一次只能載入 10 筆 <span className='text-green-500 font-bold'>&#x2713;</span></li>
                 <li>每當列表滾到底部時要需要自動發送 API 請求,並載入額外 10 筆,直到沒有更多 Task <span className='text-green-500 font-bold'>&#x2713;</span></li>
-                <li>能夠根據 Task 的狀態 (Open / In Progress / Done) 進行篩選,預設顯示所有 Task</li>
-                <li>能夠根據建立的時間進行排序,預設根據建立時間從新到舊</li>
+                <li>能夠根據 Task 的狀態 (Open / In Progress / Done) 進行篩選,預設顯示所有 Task <span className='text-green-500 font-bold'>&#x2713;</span></li>
+                <li>能夠根據建立的時間進行排序,預設根據建立時間從新到舊 <span className='text-green-500 font-bold'>&#x2713;</span></li>
                 <li>能夠根據 Task 的內容進行搜尋</li>
             </ul>
             <p className="mt-3 font-semibold">Task 詳情頁</p>


### PR DESCRIPTION
**Descriptions**:
The goals for this pull request is to allow user sort tasks by created date.
Screen shot:
![image](https://user-images.githubusercontent.com/79520786/218358726-0db1bd97-bc89-4bb6-8e61-d672a4275286.png)

**Tests**:
Tested manually through exploratory testing.
Tested manually through hover over every elements.
Tested manually through click on every elements.

**Notes**:
Future work:
1.Edit issue in detail issue page (with input validation)
2.Create issue in issue list page
3.Task Search in issue list page

Issue:
Can not update browser display in real-time after close the issue (Issue list page, issue detail page),
but Apis do work.