### PR TITLE
Feature/weiche create issue task

### DIFF
--- a/components/EditIssue.tsx
+++ b/components/EditIssue.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useState } from 'react'
+
+import { useSession } from 'next-auth/react'
+import Router from 'next/router'
+
+import Button from './Button'
+import { WorkStatus } from '@/modules/WorkStatus'
+
+type EditIssueProps = {
+    username: string;
+    reponame: string;
+}
+
+const EditIssue = (props: EditIssueProps) => {
+
+    const { data: session } = useSession()
+    const [token, setToken] = useState<any>('')
+
+
+    useEffect(() => {
+        setToken(session?.accessToken)
+    }, [])
+
+
+
+    // Handles the submit event on form submit.
+    const handleSubmit = async (event: any) => {
+
+        // Stop the form from submitting and refreshing the page.
+        event.preventDefault()
+
+        // Get data from the form.
+        const data = {
+            title: event.target.title.value,
+            body: event.target.body.value,
+            labels: [event.target.labels.value],
+        }
+
+        fetch(`https://api.github.com/repos/${props.username}/${props.reponame}/issues`, {
+            method: 'POST',
+            body: JSON.stringify(data),
+            headers: {
+                'Authorization': `bearer ${token}`,
+                'Content-type': 'application/json; charset=UTF-8',
+            },
+        })
+            .then((response) => {
+                response.json()
+                if (response.status === 201) {
+                    alert('Issue creation successfully')
+                    Router.back()
+                } else {
+                    alert(`${response.status} Issue creation failed`)
+                }
+            })
+            .then((json) => console.log(json))
+            .catch(error => console.error(error))
+    }
+
+
+    return (
+        // We pass the event to the handleSubmit() function on submit.
+        <form onSubmit={handleSubmit}>
+            <label htmlFor="title" className="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Issue title</label>
+            <div className='flex items-center justify-between'>
+
+                <input type="text" id="title" name="title"
+                    className="mr-2 block p-2.5 w-5/6 text-sm text-gray-900 bg-gray-50 rounded-lg border 
+                            border-gray-300 focus:ring-blue-500 focus:border-blue-500 
+                            dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white 
+                            dark:focus:ring-blue-500 dark:focus:border-blue-500"
+                    placeholder="Enter issue title"
+                    required />
+
+                <select name="labels" id="labels"
+                    className="block p-2.5 w-1/6 text-sm text-gray-900 bg-gray-50 rounded-lg border 
+                            border-gray-300 focus:ring-blue-500 focus:border-blue-500 
+                            dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white 
+                            dark:focus:ring-blue-500 dark:focus:border-blue-500">
+                    <option value={WorkStatus.Open}>{WorkStatus.Open}</option>
+                    <option value={WorkStatus.InProgress}>{WorkStatus.InProgress}</option>
+                    <option value={WorkStatus.Done}>{WorkStatus.Done}</option>
+                </select>
+
+            </div><br />
+
+            <label htmlFor="body" className="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Issue body</label>
+            <textarea id="body" rows={6} minLength={30}
+                className="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border 
+                        border-gray-300 focus:ring-blue-500 focus:border-blue-500 
+                        dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white 
+                        dark:focus:ring-blue-500 dark:focus:border-blue-500"
+                placeholder="Enter issue body"
+                required>
+            </textarea><br />
+
+            <div className='flex items-center justify-end'>
+                <Button className='bg-blue-300 text-black hover:bg-blue-500 hover:text-white px-6' onClick={() => { }}>Submit</Button>
+            </div>
+        </form>
+    )
+}
+
+export default EditIssue

--- a/components/EditIssue.tsx
+++ b/components/EditIssue.tsx
@@ -2,9 +2,11 @@ import { useEffect, useState } from 'react'
 
 import { useSession } from 'next-auth/react'
 import Router from 'next/router'
+import { ArrowLeftIcon } from '@heroicons/react/20/solid'
 
 import Button from './Button'
 import { WorkStatus } from '@/modules/WorkStatus'
+import { handleBackButtonClick } from './fetchGitHubApi'
 
 type EditIssueProps = {
     username: string;
@@ -60,44 +62,56 @@ const EditIssue = (props: EditIssueProps) => {
 
     return (
         // We pass the event to the handleSubmit() function on submit.
-        <form onSubmit={handleSubmit}>
-            <label htmlFor="title" className="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Issue title</label>
-            <div className='flex items-center justify-between'>
+        <div>
+            <div className='flex items-center justify-left '>
+                <div>
+                    <Button
+                        className={'mb-5 bg-gray-50 text-black hover:bg-gray-300 dark:bg-gray-900 dark:text-white dark:hover:bg-gray-700 px-2 py-2'}
+                        onClick={handleBackButtonClick}>
+                        <ArrowLeftIcon className="h-5 w-5" aria-hidden="true" />
+                    </Button>
+                </div>
+            </div>
+            <form onSubmit={handleSubmit}>
+                <label htmlFor="title" className="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Issue title</label>
+                <div className='flex items-center justify-between'>
 
-                <input type="text" id="title" name="title"
-                    className="mr-2 block p-2.5 w-5/6 text-sm text-gray-900 bg-gray-50 rounded-lg border 
+                    <input type="text" id="title" name="title"
+                        className="mr-2 block p-2.5 w-5/6 text-sm text-gray-900 bg-gray-50 rounded-lg border 
                             border-gray-300 focus:ring-blue-500 focus:border-blue-500 
                             dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white 
                             dark:focus:ring-blue-500 dark:focus:border-blue-500"
-                    placeholder="Enter issue title"
-                    required />
+                        placeholder="Enter issue title"
+                        required />
 
-                <select name="labels" id="labels"
-                    className="block p-2.5 w-1/6 text-sm text-gray-900 bg-gray-50 rounded-lg border 
+                    <select name="labels" id="labels"
+                        className="block p-2.5 w-1/6 text-sm text-gray-900 bg-gray-50 rounded-lg border 
                             border-gray-300 focus:ring-blue-500 focus:border-blue-500 
                             dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white 
                             dark:focus:ring-blue-500 dark:focus:border-blue-500">
-                    <option value={WorkStatus.Open}>{WorkStatus.Open}</option>
-                    <option value={WorkStatus.InProgress}>{WorkStatus.InProgress}</option>
-                    <option value={WorkStatus.Done}>{WorkStatus.Done}</option>
-                </select>
+                        <option value={WorkStatus.Open}>{WorkStatus.Open}</option>
+                        <option value={WorkStatus.InProgress}>{WorkStatus.InProgress}</option>
+                        <option value={WorkStatus.Done}>{WorkStatus.Done}</option>
+                    </select>
 
-            </div><br />
+                </div><br />
 
-            <label htmlFor="body" className="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Issue body</label>
-            <textarea id="body" rows={6} minLength={30}
-                className="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border 
+                <label htmlFor="body" className="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Issue body</label>
+                <textarea id="body" rows={6} minLength={30}
+                    className="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border 
                         border-gray-300 focus:ring-blue-500 focus:border-blue-500 
                         dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white 
                         dark:focus:ring-blue-500 dark:focus:border-blue-500"
-                placeholder="Enter issue body"
-                required>
-            </textarea><br />
+                    placeholder="Enter issue body"
+                    required>
+                </textarea><br />
 
-            <div className='flex items-center justify-end'>
-                <Button className='bg-blue-300 text-black hover:bg-blue-500 hover:text-white px-6' onClick={() => { }}>Submit</Button>
-            </div>
-        </form>
+                <div className='flex items-center justify-end'>
+                    <Button className='bg-blue-300 text-black hover:bg-blue-500 hover:text-white px-6' onClick={() => { }}>Submit</Button>
+                </div>
+            </form>
+        </div>
+
     )
 }
 

--- a/components/fetchGitHubApi.tsx
+++ b/components/fetchGitHubApi.tsx
@@ -61,12 +61,14 @@ export const updateIssue = async (username: string, reponame: string, issue: num
         },
     })
         .then((response) => response.json())
-        .then((json) => console.log(json));
+        .then((json) => console.log(json))
+        .catch(error => console.error(error))
 
     if (reqBody.state) {
         Router.push(`/${username}/${reponame}/issues`)
     }
 }
+
 
 export const handleBackButtonClick = () => {
     Router.back()

--- a/components/issueList.tsx
+++ b/components/issueList.tsx
@@ -78,7 +78,6 @@ const IssueList = (props: IssueListProps) => {
     // UseEffect hook to fetch the repository issues when the page number changes
     useEffect(() => {
         fetchRepoIssues(props.username, props.reponame, page, labels, sort, direction, setRepoIssues, setLoadMore, setLoading)
-        console.log(repoIssues)
     }, [page, labels, direction])
 
 

--- a/components/issueList.tsx
+++ b/components/issueList.tsx
@@ -96,9 +96,11 @@ const IssueList = (props: IssueListProps) => {
                     </div>
 
                 </div>
-                <div className='flex items-center justify-left'>
-                    <Button className='ml-2 bg-yellow-300 text-black hover:bg-yellow-500 hover:text-white px-6 py-2 ' onClick={() => { }}>Create Issue</Button>
-                </div>
+                <Link href={`/${props.username}/${props.reponame}/createIssue`}>
+                    <div className='flex items-center justify-left'>
+                        <Button className='ml-2 bg-yellow-300 text-black hover:bg-yellow-500 hover:text-white px-6 py-2 ' onClick={() => { }}>Create Issue</Button>
+                    </div>
+                </Link>
             </div>
 
             <div className='mt-2 mb-5 flex flex-row items-center justify-between'>

--- a/pages/[username]/[reponame]/createIssue.tsx
+++ b/pages/[username]/[reponame]/createIssue.tsx
@@ -1,0 +1,38 @@
+import Link from 'next/link'
+
+import { GetServerSideProps, InferGetServerSidePropsType } from 'next'
+import { ParsedUrlQuery } from 'querystring'
+
+
+import Button from '@/components/Button'
+import EditIssue from '@/components/EditIssue'
+
+// Defining an interface for the URL parameters
+interface IParams extends ParsedUrlQuery {
+    username: string;
+    reponame: string;
+};
+
+const createIssue = ({ username, reponame }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+    return (
+        <div>
+            <h1 className='mt-10 dark:text-blue-500'>{`Create issue`}</h1>
+            <h3 className='mt-5 mb-5'>Repo: {reponame}</h3>
+            <EditIssue
+                username={username}
+                reponame={reponame} />
+        </div>
+
+    )
+}
+
+// A function that fetches the data needed for the component 'Issues'
+export const getServerSideProps: GetServerSideProps = async (context) => {
+    // Extracting the parameters 'username' and 'reponame' from the URL query
+    const { username, reponame } = context.query as IParams
+
+    // Returning the extracted parameters as props for the component 'Issues'
+    return { props: { username, reponame } }
+};
+
+export default createIssue

--- a/pages/[username]/[reponame]/issues.tsx
+++ b/pages/[username]/[reponame]/issues.tsx
@@ -30,7 +30,7 @@ const Issues = ({ username, reponame }: InferGetServerSidePropsType<typeof getSe
       </div>
     </>
   )
-};
+}
 
 // A function that fetches the data needed for the component 'Issues'
 export const getServerSideProps: GetServerSideProps = async (context) => {


### PR DESCRIPTION
**Descriptions**:
The goal for this pull request is to allow user create new issue task with title, body, and work status label (with validation).
Screen shot:
![image](https://user-images.githubusercontent.com/79520786/218375695-4689b1e8-3221-489d-9479-8e6acc154c9b.png)


**Tests**:
Tested manually through exploratory testing.
Tested manually through hover over every elements.
Tested manually through click on every elements.

**Notes**:
Future work:
1.Edit issue in detail issue page (with input validation)
2.Create issue in issue list page
3.Order task in issue list page
4.Task Search in issue list page

Issue:
Can not update browser display in real-time after close the issue (Issue list page, issue detail page),
but Apis do work.